### PR TITLE
fix: use npm in workflow

### DIFF
--- a/.github/workflows/tbr.yml
+++ b/.github/workflows/tbr.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: npm ci
+      - run: npm i
       - name: Check format
         run: npm run format:check
       - name: Run build

--- a/.github/workflows/tbr.yml
+++ b/.github/workflows/tbr.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-build-release:
@@ -6,12 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: npm i
+      - run: npm ci
       - name: Check format
         run: npm run format:check
-      - name: Run build
-        run: npm run build
-      - name: Check that the current build was submitted
-        run: git diff --exit-code
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
Because @zeit/ncc produced different output in the CI than locally we removed that check.