### PR TITLE
chore: update repository template to bf0b087e

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -22,6 +22,5 @@ jobs:
       - uses: ory/closed-reference-notifier@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: ".git,**/node_modules,docs,CHANGELOG.md,.bin,*.md"
           issueLabels: upstream
           issueLimit: ${{ github.event.inputs.issueLimit || '5' }}


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/bf0b087e8893145e2067664515b1a75cb45fb92e.