### PR TITLE
chore: update repository template to bb146082

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,9 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY Closed Reference Notifier's security and our users'
-trust very seriously. If you believe you have found a security issue in ORY
-Closed Reference Notifier, please responsibly disclose by contacting us at
-security@ory.sh.
+_Please note_: We take ORY Closed Reference Notifier's security and our users' trust very
+seriously. If you believe you have found a security issue in ORY Closed Reference Notifier,
+please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
 hour of the day or night, weekdays, weekends, and holidays. Please do not ever
@@ -49,9 +48,10 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY Closed Reference Notifier's normal direction.
-A great way to do this is via
-[ORY Closed Reference Notifier Discussions](https://github.com/ory/closed-reference-notifier/discussions)
+won't clash or be obviated by ORY
+Closed Reference Notifier's normal direction. A great way to
+do this is via
+[ORY Closed Reference Notifier Discussions](https://github.com/ory/meta/discussions)
 or the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
@@ -69,8 +69,8 @@ or the [ORY Chat](https://www.ory.sh/chat).
 - I want to talk to other ORY Closed Reference Notifier users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to ORY Closed
-  Reference Notifier. Does ORY have
+- I would like to know what I am agreeing to when I contribute to ORY Closed Reference Notifier.
+  Does ORY have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/)
 
 - I would like updates about new versions of ORY Closed Reference Notifier.
@@ -85,21 +85,19 @@ There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out ORY Closed
-  Reference Notifier. Github stars help the project gain visibility and stand
-  out.
+  difference. This is something that everyone can do to help out ORY Closed Reference Notifier.
+  Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
   to their problems and offering a different perspective. Join our Slack, have a
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY Closed
-  Reference Notifier and some of them may lack necessary information, some are
-  duplicates of older issues. You can help out by guiding people through the
-  process of filling out the issue template, asking for clarifying information,
-  or pointing them to existing issues that match their description of the
-  problem.
+- **Helping with open issues.** We have a lot of open issues for ORY Closed Reference Notifier
+  and some of them may lack necessary information, some are duplicates of older
+  issues. You can help out by guiding people through the process of filling out
+  the issue template, asking for clarifying information, or pointing them to
+  existing issues that match their description of the problem.
 
 - **Reviewing documentation changes.** Most documentation just needs a review
   for proper spelling and grammar. If you think a document can be improved in
@@ -114,18 +112,16 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-Check out
-[ORY Closed Reference Notifier Discussions](https://github.com/ory/closed-reference-notifier/discussions).
-This is a great place for in-depth discussions and lots of code examples, logs
-and similar data.
+Check out [ORY Closed Reference Notifier Discussions](https://github.com/ory/meta/discussions). This is a great place for
+in-depth discussions and lots of code examples, logs and similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY Closed
-Reference Notifier, consider joining the mailing list. We will _only_ send you
-vital information on the projects that you are interested in.
+If you want to receive regular notifications about updates to ORY Closed Reference Notifier,
+consider joining the mailing list. We will _only_ send you vital information on
+the projects that you are interested in.
 
 Also [follow us on twitter](https://twitter.com/orycorp).
 
@@ -133,8 +129,8 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Closed
-Reference Notifier's roadmap and architecture.
+before getting started to ensure your work is consistent with ORY Closed Reference Notifier's
+roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
 contributors get reviewed**. After a pull request is made other contributors
@@ -164,9 +160,8 @@ should be merged by the submitter after review.
 
 Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's
-[docs](https://github.com/ory/closed-reference-notifier/tree/master/docs)
-folder. Generate API and configuration reference documentation using
-`cd docs; npm run gen`.
+[docs](https://github.com/ory/closed-reference-notifier/tree/master/docs) folder. Generate API and
+configuration reference documentation using `cd docs; npm run gen`.
 
 For further instructions please head over to
 [docs/README.md](https://github.com/ory/closed-reference-notifier/blob/master/README.md).
@@ -212,10 +207,10 @@ please include a note in your commit message explaining why.
 
 ```
 # First you clone the original repository
-git clone git@github.com:ory/Closed Reference Notifier.git
+git clone git@github.com:ory/ory/closed-reference-notifier.git
 
 # Next you add a git remote that is your fork:
-git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/Closed Reference Notifier.git
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/ory/closed-reference-notifier.git
 
 # Next you fetch the latest changes from origin for master:
 git fetch origin
@@ -251,8 +246,8 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY Closed
-  Reference Notifier core team immediately.
+  member, please contact one of the channel ops or a member of the ORY Closed Reference Notifier
+  core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/bb146082236a7bbb94c3e042951b937aa76d25a4.