### PR TITLE
chore: update repository template to 4bad4b1b

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 
 -->
 
-# Contributing to ORY Closed Reference Notifier
+# Contributing to Ory Closed Reference Notifier
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -33,8 +33,8 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY Closed Reference Notifier's security and our users'
-trust very seriously. If you believe you have found a security issue in ORY
+_Please note_: We take Ory Closed Reference Notifier's security and our users'
+trust very seriously. If you believe you have found a security issue in Ory
 Closed Reference Notifier, please responsibly disclose by contacting us at
 security@ory.sh.
 
@@ -49,31 +49,31 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY Closed Reference Notifier's normal direction.
+won't clash or be obviated by Ory Closed Reference Notifier's normal direction.
 A great way to do this is via
-[ORY Closed Reference Notifier Discussions](https://github.com/ory/meta/discussions)
-or the [ORY Chat](https://www.ory.sh/chat).
+[Ory Closed Reference Notifier Discussions](https://github.com/ory/meta/discussions)
+or the [Ory Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
 - I am new to the community. Where can I find the
-  [ORY Community Code of Conduct?](https://github.com/ory/closed-reference-notifier/blob/master/CODE_OF_CONDUCT.md)
+  [Ory Community Code of Conduct?](https://github.com/ory/closed-reference-notifier/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
-  [answers to questions regarding ORY Closed Reference Notifier?](#communication)
+  [answers to questions regarding Ory Closed Reference Notifier?](#communication)
 
 - I would like to contribute but I am not sure how. Are there
   [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other ORY Closed Reference Notifier users.
+- I want to talk to other Ory Closed Reference Notifier users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to ORY Closed
-  Reference Notifier. Does ORY have
+- I would like to know what I am agreeing to when I contribute to Ory Closed
+  Reference Notifier. Does Ory have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/closed-reference-notifier)
 
-- I would like updates about new versions of ORY Closed Reference Notifier.
+- I would like updates about new versions of Ory Closed Reference Notifier.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
 
 ## How can I contribute?
@@ -85,7 +85,7 @@ There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out ORY Closed
+  difference. This is something that everyone can do to help out Ory Closed
   Reference Notifier. Github stars help the project gain visibility and stand
   out.
 
@@ -94,7 +94,7 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY Closed
+- **Helping with open issues.** We have a lot of open issues for Ory Closed
   Reference Notifier and some of them may lack necessary information, some are
   duplicates of older issues. You can help out by guiding people through the
   process of filling out the issue template, asking for clarifying information,
@@ -112,18 +112,18 @@ a few things you can do to help out:
 ## Communication
 
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
-questions, discuss bugs and feature requests, talk to other users of ORY, etc.
+questions, discuss bugs and feature requests, talk to other users of Ory, etc.
 
 Check out
-[ORY Closed Reference Notifier Discussions](https://github.com/ory/meta/discussions).
+[Ory Closed Reference Notifier Discussions](https://github.com/ory/meta/discussions).
 This is a great place for in-depth discussions and lots of code examples, logs
 and similar data.
 
-You can also join our community hangout, if you want to speak to the ORY team
+You can also join our community hangout, if you want to speak to the Ory team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY Closed
+If you want to receive regular notifications about updates to Ory Closed
 Reference Notifier, consider joining the mailing list. We will _only_ send you
 vital information on the projects that you are interested in.
 
@@ -133,7 +133,7 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Closed
+before getting started to ensure your work is consistent with Ory Closed
 Reference Notifier's roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
@@ -150,7 +150,7 @@ from maintainers).
 Before your contributions can be merged you need to sign our
 [Contributor License Agreement](https://cla-assistant.io/ory/closed-reference-notifier).
 
-This agreement defines the terms under which your code is contributed to ORY.
+This agreement defines the terms under which your code is contributed to Ory.
 More specifically it declares that you have the right to, and actually do, grant
 us the rights to use your contribution. You can see the Apache 2.0 license under
 which our projects are published
@@ -199,9 +199,10 @@ request, go through this checklist:
 1. Run the full project test suite with the `go test ./...` (or equivalent)
    command and confirm that it passes.
 1. Run `gofmt -s` (if the project is written in Go).
-1. Ensure that each commit has a subsystem prefix (ex: `controller:`).
-   [List of subsystem prefixes for Closed Reference Notifier](https://github.com/ory/ory/closed-reference-notifier/blob/master/.github/semantic.yml)
-   (if applicable).
+1. Ensure that each commit has a descriptive prefix. This ensures a uniform
+   commit history and helps structure the changelog.  
+   Please refer to this
+   [list of prefixes for Closed Reference Notifier](https://github.com/ory/ory/closed-reference-notifier/blob/master/.github/semantic.yml).
 
 Pull requests will be treated as "review requests," and maintainers will give
 feedback on the style and substance of the patch.
@@ -253,7 +254,7 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY Closed
+  member, please contact one of the channel ops or a member of the Ory Closed
   Reference Notifier core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/4bad4b1b28491df76013a0a5c7da0b294a81ec7b.