### PR TITLE
chore: update repository template to 5485fec9

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ORY Closed Reference Notifier Forum
+  - name: Ory Closed Reference Notifier Forum
     url: https://github.com/ory/closed-reference-notifier/discussions
     about: Please ask and answer questions here, show your implementations and discuss ideas.
-  - name: ORY Chat
+  - name: Ory Chat
     url: https://www.ory.sh/chat
-    about: Hang out with other ORY community members and ask and answer questions.
-  - name: ORY Support for Business
+    about: Hang out with other Ory community members and ask and answer questions.
+  - name: Ory Support for Business
     url: https://github.com/ory/open-source-support/blob/master/README.md
-    about: Buy professional support for ORY Closed Reference Notifier.
+    about: Buy professional support for Ory Closed Reference Notifier.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/5485fec9693440f7ac1b2a7cbfadb74740bd8860.