### PR TITLE
docs: mark dist directories as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+distAction linguist-generated
+distCli linguist-generated


### PR DESCRIPTION
According to https://github.com/github/linguist/blob/master/docs/overrides.md